### PR TITLE
feat: Buildpack Setup and Configuration

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+set -eu
+
+# This script performs the buildpack transformation. BUILD_DIR will be the location of the app and CACHE_DIR will be a location the buildpack can use to cache build artifacts between builds.
+# ENV_DIR is a directory that contains a file for each of the application’s configuration variables. Config vars are made available as environment variables during execution of commands specified in the Procfile, as well as when running one-off processes.
+# See https://devcenter.heroku.com/articles/buildpack-api#bin-compile for additional documentation
+
+# Default location for sops release downloads
+PACKAGE_LOCATION="https://github.com/mozilla/sops/releases/download"
+
+# Expected environment variable coming from Heroku. See: https://devcenter.heroku.com/articles/buildpack-api#bin-compile-usage
+declare BUILD_DIR
+
+# Expected environment variable coming from Heroku. See: https://devcenter.heroku.com/articles/buildpack-api#bin-compile-usage
+declare CACHE_DIR
+
+# Expected environment variable coming from Heroku. See: https://devcenter.heroku.com/articles/buildpack-api#bin-compile-usage
+declare ENV_DIR
+
+# These are dynamic variables that the script needs to be set in the configuration vars in order to proceed. See the following sources for additional information:
+# * https://devcenter.heroku.com/articles/buildpack-api#bin-compile-summary
+# * https://devcenter.heroku.com/articles/config-vars
+declare -a SOPS_VARIABLES=(
+  "SOPS_VERSION"
+)
+
+# These variable is used as a means of communicating PATH changes in the subsequent .profile.d scripts.
+# See https://devcenter.heroku.com/articles/buildpack-api#profile-d-scripts for additional documentation
+declare SOPS_BIN
+
+# Parsing the expected arguments from Heroku in order to set the first three variables declared at the global scope
+# Any failure in this script indicates a significant change to buildpacks on Heroku
+function parse_args {
+  echo "---> Parsing expected arguments from Heroku"
+
+  if [[ $# > 3 ]]; then
+    echo "-----> Heroku has changed the arguments passed, unable to proceed"
+    exit ((1 + $#))
+  fi
+
+  BUILD_DIR=$1
+  CACHE_DIR=$2
+  ENV_DIR=$3
+}
+
+# This function handles a read of the SOPS_VERSION from the ENV_DIR passed to the script
+# This will fail if any of the variables in SOPS_VARIABLES are unset in the config vars for the application
+function read_sops_version {
+  echo "---> Processing required environment configuration"
+  local variable_dir=$1
+
+  if [[ -d ${variable_dir} ]]; then
+    for $variable in "${SOPS_VARIABLES[@]}"; do
+      local location="${variable_dir}/${variable}"
+
+      if [ ! -f $location ]; then
+        echo "-----> $variable not detected in environment, unable to proceed"
+        echo "-----> Please add $variable to the application config vars"
+        exit 1
+      fi
+
+      export "$variable=$(cat $location)"
+    done
+  fi
+}
+
+# This handles the installation of sops. If a version of sops already exists in the CACHE_DIR, no new install will be conducted
+# Once sops is installed, the artifacts will be moved into a location where we can source them into the PATH
+function install_sops {
+  echo "---> Beginning sops install, or cache lookup"
+
+  local build_location=$1
+  local cache_location=$2
+  local version=$3
+  local file="${cache_location}/sops_${version}"
+
+  mkdir -p "${cache_location}"
+  if [ ! -e $file ]; then
+    echo "-----> Installing sops version ${SOPS_VERSION}"
+  
+    curl --retry 2 \
+      --silent \
+      -L ${PACKAGE_LOCATION}/${SOPS_VERSION}/sops-${SOPS_VERSION}.linux \
+      --output sops
+    chmod +x sops
+    mv sops bin/
+  fi
+
+  SOPS_BIN="${build_location}/.sops-buildpack/"
+  mkdir -p "${SOPS_BIN}"
+  cp $file "${SOPS_BIN}/sops"
+}
+
+# Sets up the PATH modification scripts so that the sops commands can be executed easily
+function prepare_environment {
+  echo "---> Preparing environment for compatibility"
+
+  local build_location=$1
+  local bin=$2
+  local profile_location="${build_location}/.profile.d"
+
+  mkdir -p "${profile_location}"
+  echo 'export PATH="$PATH:$bin"' >> $profile_location/sops.sh
+}
+
+# Handles orchestrating of the build steps for the script
+main {
+  echo "-> sops buildpack compilation starting"
+  parse_args "$@"
+  read_sops_version $ENV_DIR
+  install_sops $BUILD_DIR $CACHE_DIR $SOPS_VERSION
+  prepare_environment $BUILD_DIR $SOPS_BIN
+  echo "-> sops buildpack compilation complete"
+}
+
+main "$@"

--- a/bin/detect
+++ b/bin/detect
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# This script takes BUILD_DIR as a single argument and must return an exit code of 0 if the app present at BUILD_DIR can be serviced by this buildpack. If the exit code is 0, the script must print a human-readable framework name to stdout.
+# See https://devcenter.heroku.com/articles/buildpack-api#bin-detect for additional documentation on this value
+
+echo "sops"
+exit 0

--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+echo "Do nothing"
+exit 0

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+git push heroku $(git rev-parse --abbrev-ref HEAD):main
+heroku run tests

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,23 @@
+# Testing the sops Buildpack
+
+The sops buildpack utilizes the instructions for testing [found on Heroku](https://devcenter.heroku.com/articles/buildpack-api#testing) which in turn is utilizing the [Buildpack TestRunner](https://github.com/heroku/heroku-buildpack-testrunner) based on [shUnit2](https://github.com/kward/shunit2/).
+
+## Running Tests
+
+First you have to set up an application
+```bash
+$ heroku create --buildpack https://github.com/heroku/heroku-buildpack-testrunner
+```
+
+Then you can execute the `run_tests.sh` scriopt after you have committed changes.
+```bash
+$ git add .
+$ git commit -m "Test run"
+$ ./run_tests.sh
+```
+
+Afterwards, tear down your environment with...
+```bash
+$ heroku apps:destroy -a <app_name>
+$ git remote rm heroku
+```

--- a/test/sops_install_test.sh
+++ b/test/sops_install_test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+testSopsInstall() {
+  assertNotNull "sops is not null" "echo $(command -v "sops")"
+}


### PR DESCRIPTION
# Background

Adds the initial buildpack setup for use on a Heroku environment. Creates the default scripts defined by the buildpack API and provides a small set suite for validating further changes.

# Implementation

* Adds `detect`, `compile` and `release` scripts
  * `detect`
    * Performs a no-op detection
  * `compile`
    * Installs a sops version based on the presence of a `SOPS_VERSION` environment variable
    * Modifies the install path to include the `sops` binary post install
    * Validates caching between builds based on the presence of `sops_${SOPS_VERSION}`
  * `release`
     * Performs a no-op echo
     * Provided for the test runner parity
* Adds test suite
  * Validates that an executable `sops` exists on the PATH

# Questions

* [x] N/A